### PR TITLE
Use `assets.exercism.org` subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A repository to store all the images used by Exercism, for example those used ac
 
 Everything must be put under `images`.
 
-URLs should currently point to `https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/[PATH_IN_THIS_REPO`. For example:
+URLs should currently point to `https://assets.exercism.org/[PATH_IN_THIS_REPO`. For example:
 - The file at `images/exercises/paint-by-number/smiley-numbers.png`
-- is hosted at https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/paint-by-number/smiley-numbers.png
+- is hosted at https://assets.exercism.org/images/exercises/paint-by-number/smiley-numbers.png


### PR DESCRIPTION
Hi there. We're moving various parts of our image hosting behind a CDN, and so various links to images are changing. This PR updates the urls we automatically found in this repository. If you come across any more links pointing to `exercism-v3-icons.s3.eu-west-2.amazonaws.com` or `dg8krxphbh767.cloudfront.net`, please change those to `assets.exercism.org` too. Thanks!