### PR TITLE
fix: remove background for cpp leap benchmark

### DIFF
--- a/images/tracks/cpp/leap/leap_benchmark_boxplot-invertible.svg
+++ b/images/tracks/cpp/leap/leap_benchmark_boxplot-invertible.svg
@@ -19,7 +19,7 @@
 	</defs>
 	<style>
 		<!-- background -->
-		.s0 { fill: #fbfbf9 }
+		.s0 { fill: none }
 		<!-- box fill -->
 		.s1 { fill: #3a3c2c }
 		<!-- median -->


### PR DESCRIPTION
I had the background in place because I thought the inverting flip function was not that near. Now it is here and it looks bad, so here is a fix.